### PR TITLE
Adding setDefaults(), ancestorCurrencyDepth option, fixing (string) NULL conversion

### DIFF
--- a/src/Smf/Menu/Renderer/BootstrapNavRenderer.php
+++ b/src/Smf/Menu/Renderer/BootstrapNavRenderer.php
@@ -8,25 +8,27 @@ use Knp\Menu\Matcher\MatcherInterface;
 use Nette\Utils\Html;
 
 /**
- * Generates navigation by adding some classes, data attributes atc.
+ * Generates Bootstrap style navigation by adding some classes, data attributes etc.
  */
 class BootstrapNavRenderer extends ListRenderer
 {
     /**
      * Overwriting some options - classes, etc.
-     * @param \Knp\Menu\Matcher\MatcherInterface $matcher
      * @param array $defaultOptions
      */
-    public function __construct(MatcherInterface $matcher, array $defaultOptions = array())
-    {
-        $defaultOptions = array_merge(array(
-            'currentClass' => 'active',
-            'ancestorClass' => 'active',
-            'firstClass' => null,
-            'lastClass' => null
-        ), $defaultOptions);
-        parent::__construct($matcher, $defaultOptions);
-    }
+	protected function setDefaults(array $defaultOptions = array())
+	{
+		$defaultOptions = array_merge(array(
+			'depth' => 1,
+			'ancestorCurrencyDepth' => null,
+			'currentClass' => 'active',
+			'ancestorClass' => 'active',
+			'firstClass' => null,
+			'lastClass' => null
+			), $defaultOptions);
+
+		parent::setDefaults($defaultOptions);
+	}
 
     /**
      * @param \Knp\Menu\ItemInterface $item
@@ -36,11 +38,11 @@ class BootstrapNavRenderer extends ListRenderer
     protected function getMenu(ItemInterface $item, array $options = array())
     {
         $menu = parent::getMenu($item, $options);
-        if (!is_null($menu)) {
+        if (is_object($menu)) {
             $menu->class = (array) $menu->class;
             array_unshift($menu->class, 'nav');
         }
-
+		
         return $menu;
     }
 


### PR DESCRIPTION
Snad s tym budes suhlasit, su to nejake fixy (hlbka rendrovania, hlbka propagacie active/current, dno na depth)

ListRenderer: calling parent::__construct(), splitting constructor and
introducing setDefaults() for easier inheritance, adding
ancestorCurrencyDepth option to mark active/current also ancestors of
not displayed menuitems (so don't stop propagation), fixing return
(string) null which is undefined, setting depth option bottom to 0
