### PR TITLE
Setting current item via ItemInterface->setCurrent()

### DIFF
--- a/src/Smf/Menu/Matcher/Matcher.php
+++ b/src/Smf/Menu/Matcher/Matcher.php
@@ -65,6 +65,7 @@ class Matcher implements IMatcher
         $childDepth = null === $depth ? null : $depth - 1;
         foreach ($item->getChildren() as $child) {
             if ($this->isCurrent($child) || $this->isAncestor($child, $childDepth)) {
+                $item->setCurrent(true);
                 return true;
             }
         }

--- a/src/Smf/Menu/Matcher/Voter/PresenterVoter.php
+++ b/src/Smf/Menu/Matcher/Voter/PresenterVoter.php
@@ -42,7 +42,8 @@ class PresenterVoter implements IVoter
     {
         if ($item->getExtra('link', false) && $this->parentControl) {
             $presenter = $this->parentControl->getPresenter(true);
-            return call_user_func_array(array($presenter, 'isLinkCurrent'), $item->getExtra('link'));
+            $item->setCurrent(call_user_func_array(array($presenter, 'isLinkCurrent'), $item->getExtra('link')));
+            return $item->isCurrent();
         }
         return null;
     }


### PR DESCRIPTION
Allows to make latte submenu like this:

``` tpl
{block #submenu}
    {foreach $presenter['menu']->getRoot()->getChildren() as $item}
        {if $item->isCurrent()}
            {* this works nicely in the first level *}
            {control menu:subMenu, path => $item->getName()}
            {breakIf true}
        {/if}
    {/foreach}
{/block}
```

Without setting `$item->setCurrent(true OR false)` in the edited files (Voter, Matcher) would the query `isCurrent()` return always NULL on any item of the menu.
