### PR TITLE
skipping null result, when the item should not be displayed

### DIFF
--- a/src/Smf/Menu/Renderer/BootstrapNavRenderer.php
+++ b/src/Smf/Menu/Renderer/BootstrapNavRenderer.php
@@ -77,7 +77,8 @@ class BootstrapNavRenderer extends ListRenderer
         if (!is_null($item)
             && $options['depth'] !== 0
             && $item->hasChildren()
-            && $item->getDisplayChildren()) {
+            && $item->getDisplayChildren()
+            && !is_null($result)) {
 
             $result->class = (array) $result->class;
             if ($this->getRealLevel($item, $options) === 1) {


### PR DESCRIPTION
adding $result->class when $result is null creates StdClass silently and yields error
later in the code
