### PR TITLE
composer: drop min stability dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,5 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
No need for this, since all required packages are stable.